### PR TITLE
fix(security): relax CSP for preview.gordonbeeming.com

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default {
 
         let csp = "";
         if (domain === "preview.gordonbeeming.com") {
-            csp = "default-src 'self'; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
+            csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
         }
         if (csp.length > 0) {
             newHeaders.set("Content-Security-Policy", csp);


### PR DESCRIPTION
Allow inline scripts and styles by adding 'unsafe-inline' to script-src
and style-src directives in the Content-Security-Policy header for the
preview.gordonbeeming.com domain. This change enables necessary inline
resources while maintaining other restrictions to improve functionality
without compromising security.