### PR TITLE
fix(security): allow additional script sources in CSP for preview

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default {
 
         let csp = "";
         if (domain === "preview.gordonbeeming.com") {
-            csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
+            csp = "default-src 'self'; script-src 'self' 'unsafe-inline' static.cloudflareinsights.com giscus.app; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
         }
         if (csp.length > 0) {
             newHeaders.set("Content-Security-Policy", csp);


### PR DESCRIPTION
Update Content-Security-Policy for preview.gordonbeeming.com to
include static.cloudflareinsights.com and giscus.app in the
script-src directive. This change enables loading necessary scripts
from these domains while maintaining strict security policies.