### PR TITLE
fix(security): allow cdn.jsdelivr.net in CSP for preview domain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "cSpell.words": [
+    "cloudflareinsights",
+    "giscus",
     "gordonbeeming",
     "hostnames",
     "nosniff",

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ export default {
 
         let csp = "";
         if (domain === "preview.gordonbeeming.com") {
-            csp = "default-src 'self'; script-src 'self' 'unsafe-inline' static.cloudflareinsights.com giscus.app; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
+            csp = "default-src 'self'; script-src 'self' 'unsafe-inline' static.cloudflareinsights.com giscus.app cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'; sandbox allow-forms allow-same-origin allow-scripts; base-uri 'self';";
         }
         if (csp.length > 0) {
             newHeaders.set("Content-Security-Policy", csp);


### PR DESCRIPTION
This pull request includes updates to improve content security policies and expand spelling dictionary entries. The key changes involve adding a new domain to the Content Security Policy (CSP) and updating the `.vscode/settings.json` file to include additional words for spell checking.

### Content Security Policy Updates:
* [`src/index.js`](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L61-R61): Added `cdn.jsdelivr.net` to the `script-src` directive in the CSP for the `preview.gordonbeeming.com` domain, allowing scripts to load from this new source.

### Spell Checking Enhancements:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R3-R4): Added `cloudflareinsights` and `giscus` to the `cSpell.words` list for improved spell checking in the development environment.