### PR TITLE
fix: add X-Origin-Content-Encoding header to response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export default {
         }
 
         let newHeaders = new Headers(response.headers);
+        newHeaders.set("X-Origin-Content-Encoding", response.headers.get("Content-Encoding") || "none");
         const contentType = newHeaders.get("Content-Type") || "";
 
         for (const [name, value] of Object.entries(securityHeaders)) {


### PR DESCRIPTION
Set a new header "X-Origin-Content-Encoding" on the response to
preserve the original Content-Encoding value or default to "none".
This helps downstream consumers identify the encoding applied by
the origin server for better handling of the response content.