### PR TITLE
feat(debug): add X-Debug-Body-Length header for HTML responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,13 @@ export default {
         let newHeaders = new Headers(response.headers);
         newHeaders.set("X-Origin-Content-Encoding", response.headers.get("Content-Encoding") || "none");
         const contentType = newHeaders.get("Content-Type") || "";
+        
+        // --- NEW DEBUG STEP: Check if the body is readable ---
+        // A response body can only be read once, so we must clone it first.
+        if (contentType.includes("text/html")) {
+            const body = await response.clone().text();
+            newHeaders.set("X-Debug-Body-Length", body.length);
+        }
 
         for (const [name, value] of Object.entries(securityHeaders)) {
             if ((domain === "iframe.gordonbeeming.com") && name === "X-Frame-Options") {


### PR DESCRIPTION
Add a debug step that clones the response body and sets a new header
X-Debug-Body-Length with the length of the HTML content. This helps
verify that the body is readable and provides insight into the response
size without consuming the original stream.