### PR TITLE
fix(security): allow 'unsafe-inline' for style-src in CSP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export default {
                 csp = [
                     ...baseCspParts,
                     `script-src 'nonce-${nonce}' 'strict-dynamic' static.cloudflareinsights.com giscus.app cdn.jsdelivr.net;`,
-                    `style-src 'nonce-${nonce}' 'self' cdn.jsdelivr.net;`,
+                    `style-src 'nonce-${nonce}' 'self' 'unsafe-inline' cdn.jsdelivr.net;`,
                 ].join(' ');
             } else {
                 csp = [


### PR DESCRIPTION
Add 'unsafe-inline' to the style-src directive in the Content Security
Policy to enable inline styles while maintaining nonce-based security.
This change addresses issues with styles not being applied correctly
due to strict CSP restrictions.