### PR TITLE
fix(security): allow popups to escape sandbox in CSP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ export default {
                 "frame-src www.youtube.com giscus.app;",
                 "worker-src 'self' blob:;",
                 "frame-ancestors 'none';",
-                "sandbox allow-forms allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-popups;",
+                "sandbox allow-forms allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-popups allow-popups-to-escape-sandbox;",
                 "base-uri 'self';"
             ];
 


### PR DESCRIPTION
Update the Content Security Policy to include the 
allow-popups-to-escape-sandbox directive in the sandbox 
attribute. This change enables popups to break out of the 
sandbox when necessary, improving compatibility with 
features that require this behavior while maintaining 
security constraints.