### PR TITLE
fix(headers): update permissions policy header to modern syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,9 +124,8 @@ export default {
             }
         }
 
-        const featurePolicy = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'";
-        newHeaders.set("Feature-Policy", featurePolicy);
-        newHeaders.set("Permissions-Policy", featurePolicy);
+        newHeaders.set("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
+        newHeaders.set("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()");
 
         if (response.status === 404) {
             console.warn(`404 Not Found: ${request.url}`);


### PR DESCRIPTION
Replace duplicated long Feature-Policy string assignment with a
concise Feature-Policy header and a modern Permissions-Policy header
using the new directive syntax (e.g. accelerometer=(), camera=()).

This ensures the Feature-Policy continues to be set and that the
Permissions-Policy uses the current browser-supported format to explicitly
deny APIs, improving compatibility and avoiding deprecated header usage.